### PR TITLE
feat: add per-genre content count tracking to session reports

### DIFF
--- a/src/context/study-session-storage.test.ts
+++ b/src/context/study-session-storage.test.ts
@@ -15,7 +15,7 @@ import {
   writeVideoAudioPreference,
   type StorageLike,
 } from "./study-session-storage"
-import { createEmptyGenreTimes } from "../utils/feed-session"
+import { createEmptyGenreCounts, createEmptyGenreTimes } from "../utils/feed-session"
 
 function createMemoryStorage(): StorageLike {
   const storage = new Map<string, string>()
@@ -73,6 +73,8 @@ describe("study session storage", () => {
     writeFeedSessionSnapshot(storage, sessionId, {
       status: "active",
       genreTimes,
+      genreCounts: createEmptyGenreCounts(),
+      seenPostIds: [],
       finalizedGenreTimes: null,
       finalReport: null,
       hasSubmitted: false,
@@ -104,6 +106,8 @@ describe("study session storage", () => {
     writeFeedSessionSnapshot(storage, firstSessionId, {
       status: "ended",
       genreTimes: createEmptyGenreTimes(),
+      genreCounts: createEmptyGenreCounts(),
+      seenPostIds: [],
       finalizedGenreTimes: null,
       finalReport: null,
       hasSubmitted: true,
@@ -134,6 +138,8 @@ describe("study session storage", () => {
     writeFeedSessionSnapshot(storage, sessionId, {
       status: "ended",
       genreTimes: createEmptyGenreTimes(),
+      genreCounts: createEmptyGenreCounts(),
+      seenPostIds: [],
       finalizedGenreTimes: null,
       finalReport: null,
       hasSubmitted: false,
@@ -155,6 +161,8 @@ describe("study session storage", () => {
     writeFeedSessionSnapshot(storage, sessionId, {
       status: "active",
       genreTimes: createEmptyGenreTimes(),
+      genreCounts: createEmptyGenreCounts(),
+      seenPostIds: [],
       finalizedGenreTimes: null,
       finalReport: null,
       hasSubmitted: false,

--- a/src/context/study-session-storage.ts
+++ b/src/context/study-session-storage.ts
@@ -1,4 +1,4 @@
-import type { GenreTimes, SessionReportPayload } from "../types/social"
+import type { GenreCounts, GenreTimes, SessionReportPayload } from "../types/social"
 
 export type InteractionState = Record<string, boolean>
 
@@ -23,6 +23,8 @@ export type FeedSessionStatus = "active" | "ended"
 export type FeedSessionSnapshot = {
   status: FeedSessionStatus
   genreTimes: GenreTimes
+  genreCounts: GenreCounts
+  seenPostIds: string[]
   finalizedGenreTimes: GenreTimes | null
   finalReport: SessionReportPayload | null
   hasSubmitted: boolean

--- a/src/hooks/use-feed-session-actions.ts
+++ b/src/hooks/use-feed-session-actions.ts
@@ -8,7 +8,7 @@ import {
 } from "react"
 import type { FeedSessionStatus } from "../context/study-session-storage"
 import { saveSessionData } from "../services/supabase"
-import type { GenreTimes, SessionReportPayload } from "../types/social"
+import type { GenreCounts, GenreTimes, SessionReportPayload } from "../types/social"
 import { getUserFacingErrorMessage } from "../utils/error-utils"
 import { buildSessionReport } from "../utils/feed-session"
 
@@ -27,6 +27,7 @@ type UseFeedSessionActionsArgs = {
   finalReportRef: MutableRefObject<SessionReportPayload | null>
   finalizeAttributedTiming: () => GenreTimes
   finalizedGenreTimesRef: MutableRefObject<GenreTimes | null>
+  genreCountsRef: MutableRefObject<GenreCounts>
   genreTimesRef: MutableRefObject<GenreTimes>
   hasSubmittedRef: MutableRefObject<boolean>
   sessionStatusRef: MutableRefObject<FeedSessionStatus>
@@ -46,6 +47,7 @@ export function useFeedSessionActions({
   finalReportRef,
   finalizeAttributedTiming,
   finalizedGenreTimesRef,
+  genreCountsRef,
   genreTimesRef,
   hasSubmittedRef,
   sessionStatusRef,
@@ -68,7 +70,7 @@ export function useFeedSessionActions({
       : finalizeAttributedTiming()
     const report =
       finalReportRef.current ??
-      buildSessionReport(studySessionId, nextGenreTimes, appVersion)
+      buildSessionReport(studySessionId, nextGenreTimes, genreCountsRef.current, appVersion)
 
     if (!finalReportRef.current) {
       finalizedGenreTimesRef.current = nextGenreTimes
@@ -153,6 +155,7 @@ export function useFeedSessionActions({
     finalReportRef,
     finalizeAttributedTiming,
     finalizedGenreTimesRef,
+    genreCountsRef,
     genreTimesRef,
     hasSubmittedRef,
     sessionStatusRef,

--- a/src/hooks/use-feed-session-snapshot.ts
+++ b/src/hooks/use-feed-session-snapshot.ts
@@ -6,13 +6,15 @@ import {
   type FeedSessionStatus,
   type FeedSessionSnapshot,
 } from "../context/study-session-storage"
-import type { GenreTimes, SessionReportPayload } from "../types/social"
+import type { GenreCounts, GenreTimes, SessionReportPayload } from "../types/social"
 
 type PersistFeedSessionSnapshotArgs = {
   finalizedGenreTimes?: GenreTimes | null
   finalReport?: SessionReportPayload | null
+  genreCounts: GenreCounts
   genreTimes: GenreTimes
   hasSubmitted?: boolean
+  seenPostIds: string[]
   status?: FeedSessionStatus
   submissionHasError?: boolean
   submissionMessage?: string | null
@@ -82,8 +84,10 @@ export function useFeedSessionSnapshot({
     ({
       finalizedGenreTimes: nextFinalizedGenreTimes = finalizedGenreTimesRef.current,
       finalReport: nextFinalReport = finalReportRef.current,
+      genreCounts,
       genreTimes,
       hasSubmitted = hasSubmittedRef.current,
+      seenPostIds,
       status = sessionStatusRef.current,
       submissionHasError: nextSubmissionHasError = submissionHasErrorRef.current,
       submissionMessage: nextSubmissionMessage = submissionMessageRef.current,
@@ -95,6 +99,8 @@ export function useFeedSessionSnapshot({
       const snapshot: FeedSessionSnapshot = {
         status,
         genreTimes,
+        genreCounts,
+        seenPostIds,
         finalizedGenreTimes: nextFinalizedGenreTimes,
         finalReport: nextFinalReport,
         hasSubmitted,

--- a/src/hooks/use-feed-session.ts
+++ b/src/hooks/use-feed-session.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, type RefObject } from "react"
 import { getSupabaseStatusMessage } from "../services/supabase"
 import type { FeedSessionStatus } from "../context/study-session-storage"
 import type { Post } from "../types/social"
-import { createEmptyGenreTimes } from "../utils/feed-session"
+import { createEmptyGenreCounts, createEmptyGenreTimes } from "../utils/feed-session"
 import { useFeedSessionActions } from "./use-feed-session-actions"
 import { useFeedSessionSnapshot } from "./use-feed-session-snapshot"
 import { useFeedTiming } from "./use-feed-timing"
@@ -45,7 +45,9 @@ export function useFeedSession({
 
   const timing = useFeedTiming({
     headerRef,
+    initialGenreCounts: snapshot.restoredSnapshot?.genreCounts ?? createEmptyGenreCounts(),
     initialGenreTimes: snapshot.restoredSnapshot?.genreTimes ?? createEmptyGenreTimes(),
+    initialSeenPostIds: new Set(snapshot.restoredSnapshot?.seenPostIds ?? []),
     isLocked: Boolean(snapshot.finalReport),
     isPaused,
     posts,
@@ -61,8 +63,10 @@ export function useFeedSession({
       return snapshot.persistSnapshot({
         finalizedGenreTimes: options.finalizedGenreTimes,
         finalReport: options.finalReport,
+        genreCounts: timing.genreCountsRef.current,
         genreTimes: nextGenreTimes,
         hasSubmitted: options.hasSubmitted,
+        seenPostIds: Array.from(timing.seenPostIdsRef.current),
         status: options.status,
         submissionHasError: options.submissionHasError,
         submissionMessage: options.submissionMessage,
@@ -136,10 +140,15 @@ export function useFeedSession({
     finalReportRef: snapshot.finalReportRef,
     finalizeAttributedTiming: timing.finalizeAttributedTiming,
     finalizedGenreTimesRef: snapshot.finalizedGenreTimesRef,
+    genreCountsRef: timing.genreCountsRef,
     genreTimesRef: timing.genreTimesRef,
     hasSubmittedRef: snapshot.hasSubmittedRef,
     sessionStatusRef: snapshot.sessionStatusRef,
-    persistSessionSnapshot: (options) => snapshot.persistSnapshot(options),
+    persistSessionSnapshot: (options) => snapshot.persistSnapshot({
+      ...options,
+      genreCounts: timing.genreCountsRef.current,
+      seenPostIds: Array.from(timing.seenPostIdsRef.current),
+    }),
     setFinalReport: snapshot.setFinalReport,
     setFinalizedGenreTimes: snapshot.setFinalizedGenreTimes,
     setSessionStatus: snapshot.setSessionStatus,

--- a/src/hooks/use-feed-timing.ts
+++ b/src/hooks/use-feed-timing.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
-import type { GenreKey, GenreTimes, Post } from "../types/social"
+import type { GenreCounts, GenreKey, GenreTimes, Post } from "../types/social"
 import {
   addFeedScrollListener,
   getFeedViewportRect,
@@ -10,7 +10,9 @@ type HeaderRef = RefObject<HTMLDivElement | null>
 
 type UseFeedTimingArgs = {
   headerRef: HeaderRef
+  initialGenreCounts: GenreCounts
   initialGenreTimes: GenreTimes
+  initialSeenPostIds: Set<string>
   isLocked: boolean
   isPaused: boolean
   posts: Post[] | null
@@ -21,15 +23,20 @@ const REGULAR_POST_SELECTOR = "[data-regular-post-id]"
 
 export function useFeedTiming({
   headerRef,
+  initialGenreCounts,
   initialGenreTimes,
+  initialSeenPostIds,
   isLocked,
   isPaused,
   posts,
   scrollRef,
 }: UseFeedTimingArgs) {
   const [genreTimes, setGenreTimes] = useState<GenreTimes>(initialGenreTimes)
+  const [genreCounts, setGenreCounts] = useState<GenreCounts>(initialGenreCounts)
   const genreMapRef = useRef<Map<string, GenreKey>>(new Map())
   const genreTimesRef = useRef<GenreTimes>(genreTimes)
+  const genreCountsRef = useRef<GenreCounts>(genreCounts)
+  const seenPostIdsRef = useRef<Set<string>>(initialSeenPostIds)
   const activePostIdRef = useRef<string | null>(null)
   const activePostStartedAtRef = useRef<number | null>(null)
   const pendingActiveStartedAtRef = useRef<number | null>(null)
@@ -38,6 +45,10 @@ export function useFeedTiming({
   useEffect(() => {
     genreTimesRef.current = genreTimes
   }, [genreTimes])
+
+  useEffect(() => {
+    genreCountsRef.current = genreCounts
+  }, [genreCounts])
 
   const commitActivePostDuration = useCallback((now = Date.now()) => {
     const activePostId = activePostIdRef.current
@@ -175,6 +186,21 @@ export function useFeedTiming({
         commitActivePostDuration(now)
       }
 
+      // Track unique post views per genre for content count analytics.
+      // A post is counted once when it first becomes the dominant post.
+      if (!seenPostIdsRef.current.has(nextPostId)) {
+        seenPostIdsRef.current.add(nextPostId)
+        const nextPostGenre = genreMapRef.current.get(nextPostId)
+        if (nextPostGenre) {
+          const nextGenreCounts = {
+            ...genreCountsRef.current,
+            [nextPostGenre]: genreCountsRef.current[nextPostGenre] + 1,
+          }
+          genreCountsRef.current = nextGenreCounts
+          setGenreCounts(nextGenreCounts)
+        }
+      }
+
       activePostIdRef.current = nextPostId
       activePostStartedAtRef.current = currentPostId
         ? now
@@ -215,8 +241,11 @@ export function useFeedTiming({
   return {
     commitActivePostDuration,
     finalizeAttributedTiming,
+    genreCounts,
+    genreCountsRef,
     genreTimes,
     genreTimesRef,
     scheduleActivePostEvaluation,
+    seenPostIdsRef,
   }
 }

--- a/src/services/supabase.test.ts
+++ b/src/services/supabase.test.ts
@@ -23,6 +23,12 @@ const payload: SessionReportPayload = {
   makanan_ms: 500,
   olahraga_ms: 0,
   game_ms: 0,
+  humor_count: 3,
+  berita_count: 1,
+  wisata_count: 0,
+  makanan_count: 1,
+  olahraga_count: 0,
+  game_count: 0,
   app_version: "without_latency",
 }
 

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -12,6 +12,7 @@ export const GENRE_KEYS = [
 export type GenreKey = (typeof GENRE_KEYS)[number]
 
 export type GenreTimes = Record<GenreKey, number>
+export type GenreCounts = Record<GenreKey, number>
 
 export type MediaItem = {
   src: string
@@ -48,5 +49,11 @@ export type SessionReportPayload = {
   makanan_ms: number
   olahraga_ms: number
   game_ms: number
+  humor_count: number
+  berita_count: number
+  wisata_count: number
+  makanan_count: number
+  olahraga_count: number
+  game_count: number
   app_version: string
 }

--- a/src/utils/feed-session.test.ts
+++ b/src/utils/feed-session.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 import {
   buildDisplayedGenreBreakdown,
+  buildSessionReport,
+  createEmptyGenreCounts,
   createEmptyGenreTimes,
   formatElapsed,
   sumGenreTimes,
@@ -25,4 +27,29 @@ describe("feed-session utilities", () => {
   it("formats elapsed time as hh : mm : ss", () => {
     expect(formatElapsed(3_723_000)).toBe("01 : 02 : 03")
   })
+
+  it("includes genre counts in the session report payload", () => {
+    const genreTimes = createEmptyGenreTimes()
+    genreTimes.humor = 5_000
+    genreTimes.berita = 2_000
+
+    const genreCounts = createEmptyGenreCounts()
+    genreCounts.humor = 3
+    genreCounts.berita = 1
+
+    const report = buildSessionReport("test_session", genreTimes, genreCounts, "test_version")
+
+    expect(report.humor_count).toBe(3)
+    expect(report.berita_count).toBe(1)
+    expect(report.wisata_count).toBe(0)
+    expect(report.makanan_count).toBe(0)
+    expect(report.olahraga_count).toBe(0)
+    expect(report.game_count).toBe(0)
+    expect(report.humor_ms).toBe(5_000)
+    expect(report.berita_ms).toBe(2_000)
+    expect(report.total_time).toBe(7_000)
+    expect(report.session_id).toBe("test_session")
+    expect(report.app_version).toBe("test_version")
+  })
 })
+

--- a/src/utils/feed-session.ts
+++ b/src/utils/feed-session.ts
@@ -1,4 +1,4 @@
-import type { GenreKey, GenreTimes, SessionReportPayload } from "../types/social"
+import type { GenreKey, GenreCounts, GenreTimes, SessionReportPayload } from "../types/social"
 
 export const GENRE_DISPLAY_ORDER: GenreKey[] = [
   "humor",
@@ -26,6 +26,17 @@ export type DisplayedGenreBreakdownRow = {
 }
 
 export function createEmptyGenreTimes(): GenreTimes {
+  return {
+    humor: 0,
+    berita: 0,
+    wisata: 0,
+    makanan: 0,
+    olahraga: 0,
+    game: 0,
+  }
+}
+
+export function createEmptyGenreCounts(): GenreCounts {
   return {
     humor: 0,
     berita: 0,
@@ -90,6 +101,7 @@ export function buildDisplayedGenreBreakdown(
 export function buildSessionReport(
   sessionId: string,
   genreTimes: GenreTimes,
+  genreCounts: GenreCounts,
   appVersion: string
 ): SessionReportPayload {
   return {
@@ -102,6 +114,12 @@ export function buildSessionReport(
     makanan_ms: genreTimes.makanan,
     olahraga_ms: genreTimes.olahraga,
     game_ms: genreTimes.game,
+    humor_count: genreCounts.humor,
+    berita_count: genreCounts.berita,
+    wisata_count: genreCounts.wisata,
+    makanan_count: genreCounts.makanan,
+    olahraga_count: genreCounts.olahraga,
+    game_count: genreCounts.game,
     app_version: appVersion,
   }
 }


### PR DESCRIPTION
- Add GenreCounts type and *_count fields to SessionReportPayload
- Track unique posts seen per genre using a Set in useFeedTiming
- Genre counts survive page refresh via sessionStorage snapshot
- Add createEmptyGenreCounts() utility and update buildSessionReport()
- Wire genreCountsRef through session hooks to Supabase payload
- Update all tests and fixtures to include the new count fields

SQL migration required in Supabase:
  ALTER TABLE feed_sessions
    ADD COLUMN IF NOT EXISTS humor_count    integer DEFAULT NULL,
    ADD COLUMN IF NOT EXISTS berita_count   integer DEFAULT NULL,
    ADD COLUMN IF NOT EXISTS wisata_count   integer DEFAULT NULL,
    ADD COLUMN IF NOT EXISTS makanan_count  integer DEFAULT NULL,
    ADD COLUMN IF NOT EXISTS olahraga_count integer DEFAULT NULL,
    ADD COLUMN IF NOT EXISTS game_count     integer DEFAULT NULL;